### PR TITLE
www.avtek.co.za

### DIFF
--- a/avtek.co.za
+++ b/avtek.co.za
@@ -1,0 +1,27 @@
+DStv Installers Cape Town
+www.avtek.co.za
+
+
+We all know of someone who has had an unfortunate experience with a DSTV installer, although we are not hiding the fact that there are dstv installation companies that have alternative business practices and there are those who have similar business practices, we are simply highlighting our strengths for you the customer so that you may make an informed decision when you employ our services to complete your DSTV installation.
+
+Rip Off Protection
+
+CT DSTV Specialists provide you with the name and cellphone number of our technician who has been assigned to your dstv installation when you pay for the installation.  If you have not been contacted by the technician within 48 hours, you are welcome to contact him, and if he does not answer or you are unsatisfied with his response you can contact our offices and we will provide you with another technician.
+
+ct_dstv_specialists_Satisfaction_Guarantee 1Accreditation from Ellies
+
+Each of the dstv satellite installers Cape Town that work for us are accredited by Ellies and they carry their accreditation with them at all times, you are welcome to ask to see the accreditation.
+
+An installer is only accredited to install the decoders, dish and other equipment, should there be any faults our installers will either direct you to our offices to deal with an accredited technician or to a DSTV technical center for the technician to assist.
+
+Packages and Bouquets
+
+CT DSTV Specialists ensure that all the bouquets and other options are chosen in your presence, we also make sure that you understand exactly what your chosen package includes and all corresponding paperwork reflects the package details.
+
+Signal Problems
+
+The qualified satellite installers employed with CT DSTV Specialists DSTV, have received full training on how to install the device to ensure the best signal possible at all times, they are also trained to recognize quickly and easily when a piece of  equipment is causing problems with the signal.
+
+Selected Channel packages
+
+The CT DSTV Specialists installers are required to ensure that every single channel available in your chosen package is open for you and shows a perfectly clear picture before they are able to complete the dstv installation services and leave your premises.  This ensures that you are getting all the channels you are paying for without further delays.


### PR DESCRIPTION
DStv Installers Cape Town
Share Button


We all know of someone who has had an unfortunate experience with a DSTV installer, although we are not hiding the fact that there are dstv installation companies that have alternative business practices and there are those who have similar business practices, we are simply highlighting our strengths for you the customer so that you may make an informed decision when you employ our services to complete your DSTV installation.

Rip Off Protection

CT DSTV Specialists provide you with the name and cellphone number of our technician who has been assigned to your dstv installation when you pay for the installation.  If you have not been contacted by the technician within 48 hours, you are welcome to contact him, and if he does not answer or you are unsatisfied with his response you can contact our offices and we will provide you with another technician.

ct_dstv_specialists_Satisfaction_Guarantee 1Accreditation from Ellies

Each of the dstv satellite installers Cape Town that work for us are accredited by Ellies and they carry their accreditation with them at all times, you are welcome to ask to see the accreditation.

An installer is only accredited to install the decoders, dish and other equipment, should there be any faults our installers will either direct you to our offices to deal with an accredited technician or to a DSTV technical center for the technician to assist.

Packages and Bouquets

CT DSTV Specialists ensure that all the bouquets and other options are chosen in your presence, we also make sure that you understand exactly what your chosen package includes and all corresponding paperwork reflects the package details.

Signal Problems

The qualified satellite installers employed with CT DSTV Specialists DSTV, have received full training on how to install the device to ensure the best signal possible at all times, they are also trained to recognize quickly and easily when a piece of  equipment is causing problems with the signal.

Selected Channel packages

The CT DSTV Specialists installers are required to ensure that every single channel available in your chosen package is open for you and shows a perfectly clear picture before they are able to complete the dstv installation services and leave your premises.  This ensures that you are getting all the channels you are paying for without further delays.www.avtek.co.za